### PR TITLE
Add call to action to SocialCG

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,7 @@
 This GitHub organization was used by the [W3C Social Web Working Group](https://www.w3.org/wiki/SocialWG) (SocialWG) for various projects & documents.
 
+The SocialWG is no longer active. Work advancing standards produced by the SocialWG is happening in the [W3C Social Web Community Group](https://www.w3.org/community/socialcg/) (SocialCG), which anyone can join. 
+
 <!-- optional things from the stub GitHub gives you for org-level READMEs:
 
 **Here are some ideas to get you started:**


### PR DESCRIPTION
This PR adds a call to action to the SocialCG to the `w3c-social` organization-level README.